### PR TITLE
Add boss and store dashboards with profitable charts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,10 +18,11 @@ import ProductAdd from "./pages/productPages/productAdd/ProductAdd.jsx";
 import TransactionList from "./pages/transactionPages/transactionList/TransactionList.jsx";
 import TransactionAdd from "./pages/transactionPages/transactionAdd/TransactionAdd.jsx";
 import TransactionDetails from "./pages/transactionPages/transactionDetails/TransactionDetails.jsx";
-import StoreDashboard from "./pages/storePages/storeDashboard/StoreDashboard.jsx";
+import StoreDashboard from "./pages/dashboardPages/storeDashboard/StoreDashboard.jsx";
 import UserProfile from "./pages/userPages/userProfile/UserProfile.jsx";
 //global
 import {GlobalStoreIdProvider} from "./api/store/GlobalStoreId.jsx";
+import BossDashboard from "./pages/dashboardPages/bossDashboard/BossDashboard.jsx";
 
 const Dashboard = () => {
     return (
@@ -102,6 +103,10 @@ const router = createBrowserRouter([
             {
                 path: "/store",
                 element: <StoreDashboard />,
+            },
+            {
+                path: "/bossDashboard",
+                element: <BossDashboard />,
             },
             {
                 path: "/profile",

--- a/src/api/category/CategoryApi.jsx
+++ b/src/api/category/CategoryApi.jsx
@@ -48,6 +48,16 @@ const getAllCategories = async () => {
         `Unexpected response status while getting categories.`
     )
 }
+
+const getTop5MostProfitableCategory = async (storeId) => {
+    const url = `${API_BASE_URL}/category/top5CategoriesByProfit/${storeId}`;
+    return apiCall(
+        url,
+        { headers: getHeaders() },
+        'Unexpected response status while getting top 5 most profitable categories.'
+    );
+};
+
 const addCategory = async (category) => {
     const url = `${API_BASE_URL}/category/add`
 
@@ -75,5 +85,6 @@ const addCategory = async (category) => {
 
 export {
     getAllCategories,
+    getTop5MostProfitableCategory,
     addCategory
 }

--- a/src/api/user/UserApi.jsx
+++ b/src/api/user/UserApi.jsx
@@ -72,6 +72,15 @@ const getAllUsers = async () => {
     return apiCall(url, { headers: getHeaders() }, "Error getting all users:");
 };
 
+const getTop3EmployeesByStoreProfit = async () => {
+    const url = `${API_BASE_URL}/user/top3EmployeesByStoreProfit`;
+    return apiCall(
+        url,
+        { headers: getHeaders() },
+        'Unexpected response status while getting top 3 most profitable Employee.'
+    );
+};
+
 
 const addAccount = async (formData) => {
     const url = `${API_BASE_URL}/account/addAccount`;
@@ -144,6 +153,7 @@ export
     getUsersByStoreId,
     getAllUsers,
     getUsersByStoreIdAndRoles,
+    getTop3EmployeesByStoreProfit,
     //add methods
     addAccount,
     //update methods

--- a/src/pages/dashboardPages/bossDashboard/BossDashboard.jsx
+++ b/src/pages/dashboardPages/bossDashboard/BossDashboard.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Top3Employee from './Top3Employee'; // Top3Employee bileşenini import edin
+
+const BossDashboard = () => {
+    return (
+        <div className="container mx-auto p-4">
+            <h1 className="text-3xl font-bold mb-6 text-center">Boss Dashboard</h1>
+            <div className="flex flex-col md:flex-row justify-between">
+                <div className="md:w-full p-2">
+                    <Top3Employee />
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default BossDashboard;

--- a/src/pages/dashboardPages/bossDashboard/Top3Employee.jsx
+++ b/src/pages/dashboardPages/bossDashboard/Top3Employee.jsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from 'react';
+import { Bar } from 'react-chartjs-2';
+import { getTop3EmployeesByStoreProfit } from '../../../api/user/UserApi';
+import Chart from 'chart.js/auto';
+
+const Top3Employee = () => {
+    const [employees, setEmployees] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        const fetchEmployeeData = async () => {
+            try {
+                const response = await getTop3EmployeesByStoreProfit();
+                setEmployees(response.data);
+                setLoading(false);
+            } catch (error) {
+                setError(`Error fetching top 3 employees: ${error.message}`);
+                setLoading(false);
+            }
+        };
+
+        fetchEmployeeData();
+    }, []);
+
+    if (loading) {
+        return <div>Loading...</div>;
+    }
+
+    if (error) {
+        return <div>{error}</div>;
+    }
+
+    const data = {
+        labels: employees.map(employee => `${employee.name} ${employee.surname}`),
+        datasets: [
+            {
+                label: 'Total Profit',
+                data: employees.map(employee => employee.totalProfit),
+                backgroundColor: [
+                    'rgba(255, 99, 132, 0.6)',  // Kırmızı
+                    'rgba(54, 162, 235, 0.6)',  // Mavi
+                    'rgba(75, 192, 192, 0.6)',  // Yeşil
+                ],
+                borderColor: [
+                    'rgba(255, 99, 132, 1)',
+                    'rgba(54, 162, 235, 1)',
+                    'rgba(75, 192, 192, 1)',
+                ],
+                borderWidth: 1,
+            },
+        ],
+    };
+
+    const options = {
+        responsive: true,
+        scales: {
+            y: {
+                beginAtZero: true,
+                ticks: {
+                    callback: function(value) {
+                        return '$' + value.toLocaleString(); // Kar değerini para birimi olarak göster
+                    },
+                },
+            },
+        },
+        plugins: {
+            legend: {
+                display: false, // Legend gizlendi
+            },
+            tooltip: {
+                callbacks: {
+                    label: function(context) {
+                        let label = context.dataset.label || '';
+                        if (label) {
+                            label += ': ';
+                        }
+                        if (context.parsed.y !== null) {
+                            label += '$' + context.parsed.y.toLocaleString();
+                        }
+                        return label;
+                    },
+                },
+            },
+        },
+    };
+
+    return (
+        <div className="bg-white p-6 rounded-lg shadow-lg w-full">
+            <h2 className="text-2xl font-bold mb-6 text-center">Top 3 Most Profitable Employees</h2>
+            <Bar data={data} options={options} />
+        </div>
+    );
+};
+
+export default Top3Employee;

--- a/src/pages/dashboardPages/bossDashboard/Top3Store.jsx
+++ b/src/pages/dashboardPages/bossDashboard/Top3Store.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+function Top3Store(props) {
+    return (
+        <div></div>
+    );
+}
+
+export default Top3Store;

--- a/src/pages/dashboardPages/storeDashboard/ProfitChart.jsx
+++ b/src/pages/dashboardPages/storeDashboard/ProfitChart.jsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { Line } from 'react-chartjs-2';
 import { Chart as ChartJS, LineElement, CategoryScale, LinearScale, Title, Tooltip, Legend, PointElement } from 'chart.js';
-import { getDailyTotalTransactions } from '../../../api/transaction/TransactionApi';
-import { GlobalStoreId } from '../../../api/store/GlobalStoreId';
-import { decodeUserToken } from '../../../api/authentication/AuthenticationApi';
+import { getDailyTotalTransactions } from '../../../api/transaction/TransactionApi.jsx';
+import { GlobalStoreId } from '../../../api/store/GlobalStoreId.jsx';
+import { decodeUserToken } from '../../../api/authentication/AuthenticationApi.jsx';
 
 ChartJS.register(LineElement, CategoryScale, LinearScale, Title, Tooltip, Legend, PointElement);
 

--- a/src/pages/dashboardPages/storeDashboard/StoreDashboard.jsx
+++ b/src/pages/dashboardPages/storeDashboard/StoreDashboard.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import ProfitChart from './ProfitChart';
-import Top5Products from './Top5Products';
+import ProfitChart from './ProfitChart.jsx';
+import Top5Products from './Top5Products.jsx';
+import Top5Category from './Top5Category.jsx'; // Top5Category bileşenini import edin
 
 const StoreDashboard = () => {
     const { storeId } = useParams();
@@ -16,6 +17,9 @@ const StoreDashboard = () => {
                 <div className="md:w-1/2 p-2">
                     <Top5Products storeId={storeId} />
                 </div>
+            </div>
+            <div className="mt-6">
+                <Top5Category storeId={storeId} /> {/* Top5Category bileşenini ekleyin */}
             </div>
         </div>
     );

--- a/src/pages/dashboardPages/storeDashboard/Top5Category.jsx
+++ b/src/pages/dashboardPages/storeDashboard/Top5Category.jsx
@@ -1,0 +1,112 @@
+import React, { useState, useEffect, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Bar } from 'react-chartjs-2';
+import { getTop5MostProfitableCategory } from '../../../api/category/CategoryApi.jsx';
+import { GlobalStoreId } from "../../../api/store/GlobalStoreId.jsx";
+import { decodeUserToken } from "../../../api/authentication/AuthenticationApi.jsx";
+import Chart from 'chart.js/auto';
+
+const COLORS = [
+    'rgba(75, 192, 192, 0.6)',
+    'rgba(75, 192, 75, 0.6)',
+    'rgba(255, 206, 86, 0.6)',
+    'rgba(153, 102, 255, 0.6)',
+    'rgba(255, 105, 180, 0.6)',
+    'rgba(255, 99, 132, 0.6)',
+];
+
+const BORDER_COLORS = [
+    'rgba(75, 192, 192, 1)',
+    'rgba(75, 192, 75, 1)',
+    'rgba(255, 206, 86, 1)',
+    'rgba(153, 102, 255, 1)',
+    'rgba(255, 105, 180, 1)',
+    'rgba(255, 99, 132, 1)',
+];
+
+const Top5Category = ({ storeId }) => {
+    const [categories, setCategories] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const navigate = useNavigate();
+    const { globalStoreId } = useContext(GlobalStoreId);
+
+    const determineStoreId = () => {
+        const token = decodeUserToken();
+        if (token && (token.role === 'MANAGER' || token.role === 'USER')) {
+            return token.storeId;
+        }
+        return globalStoreId;
+    };
+
+    useEffect(() => {
+        const id = storeId || determineStoreId();
+
+        const fetchCategoryData = async () => {
+            try {
+                const response = await getTop5MostProfitableCategory(id);
+                setCategories(response.data);
+                setLoading(false);
+            } catch (error) {
+                setError(`Error fetching top 5 most profitable categories: ${error.message}`);
+                setLoading(false);
+            }
+        };
+
+        fetchCategoryData();
+    }, [storeId, globalStoreId]);
+
+    useEffect(() => {
+        return () => {
+            for (let id in Chart.instances) {
+                Chart.instances[id].destroy();
+            }
+        };
+    }, []);
+
+    if (loading) {
+        return <div>Loading...</div>;
+    }
+
+    if (error) {
+        return <div>{error}</div>;
+    }
+
+    const data = {
+        labels: categories.map((category) => category.categoryName),
+        datasets: [
+            {
+                label: 'Total Profit',
+                data: categories.map((category) => category.totalProfit),
+                backgroundColor: categories.map((_, index) => COLORS[index % COLORS.length]),
+                borderColor: categories.map((_, index) => BORDER_COLORS[index % BORDER_COLORS.length]),
+                borderWidth: 1,
+            },
+        ],
+    };
+
+    const options = {
+        scales: {
+            y: {
+                beginAtZero: true,
+            },
+        },
+    };
+
+    return (
+        <div className="bg-white p-6 rounded-lg shadow-lg w-full">
+            <h2 className="text-2xl font-bold mb-6 text-center">Top 5 Most Profitable Categories</h2>
+            <Bar data={data} options={options} />
+            <div className="flex justify-center mt-6">
+                <button
+                    onClick={() => navigate('/category-list')}
+                    className="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-5 py-3 rounded-lg shadow-md"
+                >
+                    View All Categories
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default Top5Category;

--- a/src/pages/dashboardPages/storeDashboard/Top5Products.jsx
+++ b/src/pages/dashboardPages/storeDashboard/Top5Products.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { getTop5MostProfitableProducts } from '../../../api/store/StoreApi';
-import { GlobalStoreId } from "../../../api/store/GlobalStoreId";
-import { decodeUserToken } from "../../../api/authentication/AuthenticationApi";
+import { getTop5MostProfitableProducts } from '../../../api/store/StoreApi.jsx';
+import { GlobalStoreId } from "../../../api/store/GlobalStoreId.jsx";
+import { decodeUserToken } from "../../../api/authentication/AuthenticationApi.jsx";
 
 const Top5Products = () => {
     const [products, setProducts] = useState([]);


### PR DESCRIPTION
Different dashboard components have been created for the boss and store. Boss dashboard consists of top profitable employees and store dashboard includes top profitable categories and products. Necessary API calls were also added to fetch the necessary data for these components. The folder structure has also been updated to reflect these changes.